### PR TITLE
Fix: Reduce empty space around category icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,8 +430,7 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
         }
         .category-icon-wrapper {
             background-color: var(--primary-color);
-            width: 60px;
-            height: 60px;
+            padding: 1rem;
             border-radius: 12px;
             display: flex;
             align-items: center;


### PR DESCRIPTION
Replaced fixed width and height with padding on the .category-icon-wrapper to reduce unnecessary empty space and improve the visual appeal of the product category icons.