### PR TITLE
Fix: Update category icon size to match mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,8 +430,9 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
         }
         .category-icon-wrapper {
             background-color: var(--primary-color);
-            padding: 1rem;
-            border-radius: 12px;
+            width: 40px;
+            height: 40px;
+            border-radius: 7px;
             display: flex;
             align-items: center;
             justify-content: center;


### PR DESCRIPTION
Updated the base styles for the .category-icon-wrapper to match the mobile styles, reducing the size of the icon wrapper on desktop to create a more consistent look and feel across all devices.