### PR TITLE
Fix: Set fixed size for category cards on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,6 +456,8 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
         @media (min-width: 769px) {
             .category {
                 flex: 0 0 calc(25% - 1rem);
+                width: 310px;
+                height: 306px;
             }
         }
         .category-name { font-size: 1.1rem; font-weight: 600; color: var(--text-color); line-height: 1.3; margin-bottom: 0.35rem; }


### PR DESCRIPTION
I've set a fixed size of 310px by 306px for the product category cards on the desktop version to ensure a consistent layout.