### PR TITLE
Fix: Update category card to be square and revert icon size

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,7 +443,7 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
             transform: scale(1.05);
         }
         .category i.category-icon-fa {
-            font-size: 1.25rem;
+            font-size: 1.8rem;
             color: white;
             display: block;
             line-height: 1;
@@ -456,7 +456,7 @@ src="https://www.facebook.com/tr?id=482675157669768&ev=PageView&noscript=1"
         @media (min-width: 769px) {
             .category {
                 flex: 0 0 calc(25% - 1rem);
-                width: 30px;
+                width: 140px;
                 height: 140px;
             }
         }


### PR DESCRIPTION
Updated the category card size to 140px by 140px on the desktop version to make it square. Reverted the icon font size to 1.8rem.